### PR TITLE
fix incorrect bundling

### DIFF
--- a/jest.transform.js
+++ b/jest.transform.js
@@ -16,7 +16,7 @@ module.exports = {
                 define: { "process.env.NODE_ENV": '"development"' },
                 jsx: "automatic",
                 jsxDev: false,
-                jsxImportSource: ".",
+                jsxImportSource: "@/jsx",
                 format: "cjs",
                 target: "esnext",
                 platform: "node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hytts/hytts",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "author": "Axel Habermaier",
     "license": "MIT",
     "homepage": "https://github.com/HyTTS/HyTTS",
@@ -9,8 +9,13 @@
         "url": "https://github.com/HyTTS/HyTTS"
     },
     "main": "index.js",
+    "exports": {
+        "./jsx-runtime": "./index.js",
+        "./jsx-dev-runtime": "./index.js",
+        ".": "./index.js"
+    },
     "scripts": {
-        "build": "tsup ./source/index.ts --clean --dts --format=cjs --target=node18 --env.NODE_ENV production && tsup ./source/jsx-dev-runtime.ts --dts --format=cjs --target=node18 --env.NODE_ENV production && tsup ./source/jsx-runtime.ts --dts --format=cjs --target=node18 --env.NODE_ENV production && cp ./package.json ./dist/package.json && cp ./README.md ./dist/README.md",
+        "build": "tsup ./source/index.ts --clean --dts --format=cjs --target=node18 --env.NODE_ENV production && cp ./package.json ./dist/package.json && cp ./README.md ./dist/README.md && echo 'export { JSX } from \"./index\";' > ./dist/jsx-runtime.d.ts",
         "publish:local": "yarn build && cd ./dist && npm pack --pack-destination ../tmp",
         "format:check": "prettier --check ./",
         "format:fix": "prettier --write --loglevel warn ./",

--- a/source/index.ts
+++ b/source/index.ts
@@ -21,7 +21,15 @@ export { type CspNonceProviderProps, CspNonceProvider, useCspNonce } from "@/jsx
 
 export { type ErrorBoundaryProps, type ErrorViewProps, ErrorBoundary } from "@/jsx/error-boundary";
 
-export { Fragment, renderToString } from "@/jsx/jsx-runtime";
+export {
+    jsx,
+    jsx as jsxDEV,
+    jsxs as jsxsDEV,
+    jsxs,
+    Fragment,
+    renderToString,
+    type JSX,
+} from "@/jsx/jsx-runtime";
 
 export type {
     EventArgs,

--- a/source/jsx-dev-runtime.ts
+++ b/source/jsx-dev-runtime.ts
@@ -1,1 +1,0 @@
-export { jsx as jsxDEV, jsxs as jsxsDEV, Fragment, type JSX } from "@/jsx/jsx-runtime";

--- a/source/jsx-runtime.ts
+++ b/source/jsx-runtime.ts
@@ -1,1 +1,0 @@
-export { jsx, jsxs, Fragment, type JSX } from "@/jsx/jsx-runtime";

--- a/source/jsx/jsx-types.ts
+++ b/source/jsx/jsx-types.ts
@@ -5,6 +5,8 @@ import type { BrowserFunc } from "./browser-script";
 /** The types that are supported as children of a JSX expression. */
 export type JsxNode = JsxElement | string | number | boolean | null | undefined | JsxNode[];
 
+const jsxExpressionSymbol = Symbol();
+
 /**
  * The runtime type of an JSX expression like `<div/>`, i.e., a function returning the rendered HTML string
  * in the simplest case. Since components can be `async`, however, a JSX expression can alternatively return
@@ -13,7 +15,7 @@ export type JsxNode = JsxElement | string | number | boolean | null | undefined 
  */
 export type JsxExpression = {
     (): string | null | Promise<string | null>;
-    __isJsxExpression: null; // Prevents inadvertent usage of regular values as JsxExpressions
+    [jsxExpressionSymbol]: null;
 };
 
 /**
@@ -61,7 +63,7 @@ export type EventArgs<TElement = HTMLElement, TEvent extends Event = Event> = TE
  * arbitrary function as a JSX child.
  */
 export function toJsxExpression(action: () => ReturnType<JsxExpression>): JsxExpression {
-    (action as any).__isJsxExpression = null;
+    (action as any)[jsxExpressionSymbol] = null;
     return action as JsxExpression;
 }
 
@@ -69,7 +71,7 @@ export function toJsxExpression(action: () => ReturnType<JsxExpression>): JsxExp
  * Checks whether the given value is a JSX expression and can thus safely be rendered as a JSX child.
  */
 export function isJsxExpression(value: unknown): value is JsxExpression {
-    return !!value && typeof value === "function" && "__isJsxExpression" in value;
+    return !!value && typeof value === "function" && jsxExpressionSymbol in value;
 }
 
 // ================================================================================================================

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "isolatedModules": true,
         "esModuleInterop": true,
         "jsx": "react-jsx",
-        "jsxImportSource": ".",
+        "jsxImportSource": "@/jsx",
         "moduleResolution": "node",
         "resolveJsonModule": true,
         "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
* fix incorrect package bundling which resulted in multiple symbols being used for the same context, causing rendering errors
* switch back to using symbols for JSX expressions and browser funcs/scripts