### PR TITLE
browser script improvements

### DIFF
--- a/source/dom/frame.tsx
+++ b/source/dom/frame.tsx
@@ -48,10 +48,7 @@ export function createFrame(frameId: string): Frame {
     return frame;
 }
 
-/**
- * Provides access to the metadata of frame that contains the caller within the component tree. The
- * document's body is the top-most frame element.
- */
+/** Provides access to the metadata of the caller's nearest ancestor frame. */
 export function useFrameMetadata() {
     return useContext(frameContext);
 }

--- a/source/dom/html.tsx
+++ b/source/dom/html.tsx
@@ -1,6 +1,7 @@
 import { renderToString } from "@/jsx/jsx-runtime";
 import { type JSX, type JsxElement, toJsxExpression } from "@/jsx/jsx-types";
 
+/** Renders the `<html>` element and prefixes the HTML output with a `DOCTYPE` declaration. */
 export function Html(props: JSX.HTMLAttributes<HTMLHtmlElement>): JsxElement {
     return toJsxExpression(
         async () => "<!DOCTYPE html>" + (await renderToString(<html {...props} />)),

--- a/source/index.ts
+++ b/source/index.ts
@@ -2,12 +2,13 @@ export {
     type BrowserFunc,
     type BrowserScript,
     type CapturedVariable,
-    BrowserScriptRenderer,
+    type HandlerProps,
+    type ScriptProps,
     createBrowserFunc,
     createBrowserScript,
     createEventHandler,
-    useRegisterBrowserEventHandler,
-    useRegisterBrowserScript,
+    Handler,
+    Script,
 } from "@/jsx/browser-script";
 
 export {

--- a/source/jsx/error-boundary.ts
+++ b/source/jsx/error-boundary.ts
@@ -12,7 +12,7 @@ export type ErrorViewProps = {
 };
 
 export type ErrorBoundaryProps = PropsWithChildren<{
-    /** The component that is rendered if an error was thrown while rendering of the children. */
+    /** The component that is rendered if an error was thrown while rendering the children. */
     readonly ErrorView: JsxComponent<ErrorViewProps>;
 }>;
 


### PR DESCRIPTION
* switch to making document/layout explicit per route so that frame-only routes can be rendered more efficiently
* this also removes the need for the router's `meta` function (will be removed in a separate PR)
* improve script handling with `Script` and `Handler` components as opposed to hooks so that it is clearer where the resulting JavaScript code gets emitted
* emit `<script>` tags immediately for `Script` components instead of at the end of the frame